### PR TITLE
request cards' attachments

### DIFF
--- a/src/fetch.js
+++ b/src/fetch.js
@@ -10,7 +10,7 @@ class TrelloSource {
   }
 
   async getBoards(id) {
-    const url = `${this.TrelloBaseURL}/boards/${id}?fields=all&lists=all&cards=all&customFields=true&card_customFieldItems=true&key=${this._key}&token=${this._secret}`
+    const url = `${this.TrelloBaseURL}/boards/${id}?fields=all&lists=all&cards=all&card_attachments=true&customFields=true&card_customFieldItems=true&key=${this._key}&token=${this._secret}`
     const data = await request.get(url)
     return data
   }


### PR DESCRIPTION
Added  `card_attachments=true` to get cards' attachment
refer: https://developers.trello.com/reference#cards-nested-resource

By default, cards don't have data around attachments.
This resolves the issue below.

https://github.com/Necmttn/gatsby-source-trello/issues/6